### PR TITLE
docs: update README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ In addition, the source code summary is accompanied by detailed code comments fo
 - git
 - make
 - g++
-- qt5-default
+- qtbase5-dev
+- qtchooser
+- qt5-qmake
+- qtbase5-dev-tools
 - qtmultimedia5-dev
 
 ## Build:
@@ -138,9 +141,9 @@ In addition, the source code summary is accompanied by detailed code comments fo
    For Debian and Ubuntu, run:
    
    ```bash
-   $ sudo apt install -y git make g++ qt5-default qtmultimedia5-dev
+   $ sudo apt install -y git make g++ qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools qtmultimedia5-dev
    ```
-
+   
 2. Run the command::
 
    ```bash

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -126,7 +126,10 @@
 - git
 - make
 - g++
-- qt5-default
+- qtbase5-dev
+- qtchooser
+- qt5-qmake
+- qtbase5-dev-tools
 - qtmultimedia5-dev
 
 ## 构建：
@@ -136,7 +139,7 @@
    以 Debian 和 Ubuntu 为例，执行:
    
    ```bash
-   $ sudo apt install -y git make g++ qt5-default qtmultimedia5-dev
+   $ sudo apt install -y git make g++ qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools qtmultimedia5-dev
    ```
    
 2. 运行命令:


### PR DESCRIPTION
 The package `qt5-default` is no longer available since Debian 11 and Ubuntu 20.04.